### PR TITLE
docs: link to GitHub if mermaid graph doesn't render

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ When `loader` is not provided in the options explicitly, it will read from `IMPO
 
 ### `auto`
 
-Automatically choose the best loader based on the environment.
+Automatically choose the best loader based on the environment (if the below graph doesn't render, [click here to view it on GitHub](https://github.com/antfu-collective/importx#auto)).
 
 ```mermaid
 graph TD


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

link to GitHub in the readme if mermaid graph doesn't render (e.g. on npmjs.com/package/importx)

### Linked Issues

Closes #9

### Additional context

Ideally npm would render like GitHub does. If they start doing that this should be reverted.

Another option would be to preprocess the readme before packing, but probably only worth doing if there's also another more important reason for preprocessing
