### PR TITLE
chore: drop unused `pkg-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "jiti": "2.0.0-beta.2",
     "jiti-v1": "npm:jiti@^1",
     "pathe": "^1.1.2",
-    "pkg-types": "^1.1.3",
     "tsx": "^4.16.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
-      pkg-types:
-        specifier: ^1.1.3
-        version: 1.1.3
       tsx:
         specifier: ^4.16.2
         version: 4.16.2


### PR DESCRIPTION
### Description

It seems that `pkg-types` is no longer used inside `importx` but still remains in `dependencies`. The PR removes `pkg-types` in `package.json`.

### Linked Issues

https://github.com/antfu-collective/taze/issues/138

### Additional context

This PR is a part of attempts to reduce `taze`'s installation size.

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/0187e386-f52c-4533-a1ce-0ff75b155e7a">