### PR TITLE
feat: detect native typescript support on node

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -79,6 +79,11 @@ let _isNativeTsImportSupported: boolean | undefined
 
 export async function isNativeTsImportSupported(): Promise<boolean> {
   if (_isNativeTsImportSupported === undefined) {
+    // @ts-expect-error missing `typescript` property
+    // eslint-disable-next-line node/prefer-global/process
+    if (typeof process !== 'undefined' && process.features?.typescript) {
+      return _isNativeTsImportSupported = true
+    }
     try {
       const modName = 'dummy.mts'
       const mod = await import(`../runtime-fixtures/${modName}`)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Support native TS feature with `--experimental-strip-types` or `--experimental-transform-types` flag on node.

Since currently node doesn't support import TS files inside of `node_modules` folders, so import `dummy.mts` will be failed.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
